### PR TITLE
feat: Add AR Rugby game page

### DIFF
--- a/affiliates.html
+++ b/affiliates.html
@@ -32,6 +32,7 @@
             <li><a href="developer_tools.html">Developer Tools</a></li>
             <li><a href="ai_agent.html">AI Agent</a></li>
             <li><a href="github_explorer.html">GitHub Explorer</a></li>
+            <li><a href="rugby_game.html">AR Rugby</a></li>
         </ul>
     </nav>
     <main>

--- a/ai_agent.html
+++ b/ai_agent.html
@@ -32,6 +32,7 @@
             <li><a href="developer_tools.html">Developer Tools</a></li>
             <li><a href="ai_agent.html">AI Agent</a></li>
             <li><a href="github_explorer.html">GitHub Explorer</a></li>
+            <li><a href="rugby_game.html">AR Rugby</a></li>
         </ul>
     </nav>
     <main>

--- a/ai_mmo_games.html
+++ b/ai_mmo_games.html
@@ -31,6 +31,7 @@
             <li><a href="developer_tools.html">Developer Tools</a></li>
             <li><a href="ai_agent.html">AI Agent</a></li>
             <li><a href="github_explorer.html">GitHub Explorer</a></li>
+            <li><a href="rugby_game.html">AR Rugby</a></li>
         </ul>
     </nav>
     <main>

--- a/camera_features.html
+++ b/camera_features.html
@@ -32,6 +32,7 @@
             <li><a href="developer_tools.html">Developer Tools</a></li>
             <li><a href="ai_agent.html">AI Agent</a></li>
             <li><a href="github_explorer.html">GitHub Explorer</a></li>
+            <li><a href="rugby_game.html">AR Rugby</a></li>
         </ul>
     </nav>
     <main>

--- a/casino_games.html
+++ b/casino_games.html
@@ -31,6 +31,7 @@
             <li><a href="developer_tools.html">Developer Tools</a></li>
             <li><a href="ai_agent.html">AI Agent</a></li>
             <li><a href="github_explorer.html">GitHub Explorer</a></li>
+            <li><a href="rugby_game.html">AR Rugby</a></li>
         </ul>
     </nav>
     <main>

--- a/cloud_gaming.html
+++ b/cloud_gaming.html
@@ -32,6 +32,7 @@
             <li><a href="developer_tools.html">Developer Tools</a></li>
             <li><a href="ai_agent.html">AI Agent</a></li>
             <li><a href="github_explorer.html">GitHub Explorer</a></li>
+            <li><a href="rugby_game.html">AR Rugby</a></li>
         </ul>
     </nav>
     <main>

--- a/developer_tools.html
+++ b/developer_tools.html
@@ -51,6 +51,7 @@
             <li><a href="developer_tools.html">Developer Tools</a></li>
             <li><a href="ai_agent.html">AI Agent</a></li>
             <li><a href="github_explorer.html">GitHub Explorer</a></li>
+            <li><a href="rugby_game.html">AR Rugby</a></li>
         </ul>
     </nav>
     <main>

--- a/esport_games.html
+++ b/esport_games.html
@@ -32,6 +32,7 @@
             <li><a href="developer_tools.html">Developer Tools</a></li>
             <li><a href="ai_agent.html">AI Agent</a></li>
             <li><a href="github_explorer.html">GitHub Explorer</a></li>
+            <li><a href="rugby_game.html">AR Rugby</a></li>
         </ul>
     </nav>
     <main>

--- a/forums.html
+++ b/forums.html
@@ -31,6 +31,7 @@
             <li><a href="developer_tools.html">Developer Tools</a></li>
             <li><a href="ai_agent.html">AI Agent</a></li>
             <li><a href="github_explorer.html">GitHub Explorer</a></li>
+            <li><a href="rugby_game.html">AR Rugby</a></li>
         </ul>
     </nav>
     <main>

--- a/github_explorer.html
+++ b/github_explorer.html
@@ -66,6 +66,7 @@
             <li><a href="developer_tools.html">Developer Tools</a></li>
             <li><a href="ai_agent.html">AI Agent</a></li>
             <li><a href="github_explorer.html">GitHub Explorer</a></li>
+            <li><a href="rugby_game.html">AR Rugby</a></li>
         </ul>
     </nav>
     <main>

--- a/global_gambles.html
+++ b/global_gambles.html
@@ -31,6 +31,7 @@
             <li><a href="developer_tools.html">Developer Tools</a></li>
             <li><a href="ai_agent.html">AI Agent</a></li>
             <li><a href="github_explorer.html">GitHub Explorer</a></li>
+            <li><a href="rugby_game.html">AR Rugby</a></li>
         </ul>
     </nav>
     <main>

--- a/index.html
+++ b/index.html
@@ -32,6 +32,7 @@
             <li><a href="developer_tools.html">Developer Tools</a></li>
             <li><a href="ai_agent.html">AI Agent</a></li>
             <li><a href="github_explorer.html">GitHub Explorer</a></li>
+            <li><a href="rugby_game.html">AR Rugby</a></li>
         </ul>
     </nav>
     <div style="text-align: center; padding: 20px;">

--- a/instant_games.html
+++ b/instant_games.html
@@ -32,6 +32,7 @@
             <li><a href="developer_tools.html">Developer Tools</a></li>
             <li><a href="ai_agent.html">AI Agent</a></li>
             <li><a href="github_explorer.html">GitHub Explorer</a></li>
+            <li><a href="rugby_game.html">AR Rugby</a></li>
         </ul>
     </nav>
     <main>

--- a/manga_games.html
+++ b/manga_games.html
@@ -31,6 +31,7 @@
             <li><a href="developer_tools.html">Developer Tools</a></li>
             <li><a href="ai_agent.html">AI Agent</a></li>
             <li><a href="github_explorer.html">GitHub Explorer</a></li>
+            <li><a href="rugby_game.html">AR Rugby</a></li>
         </ul>
     </nav>
     <main>

--- a/monetization.html
+++ b/monetization.html
@@ -32,6 +32,7 @@
             <li><a href="developer_tools.html">Developer Tools</a></li>
             <li><a href="ai_agent.html">AI Agent</a></li>
             <li><a href="github_explorer.html">GitHub Explorer</a></li>
+            <li><a href="rugby_game.html">AR Rugby</a></li>
         </ul>
     </nav>
     <main>

--- a/partnerships.html
+++ b/partnerships.html
@@ -32,6 +32,7 @@
             <li><a href="developer_tools.html">Developer Tools</a></li>
             <li><a href="ai_agent.html">AI Agent</a></li>
             <li><a href="github_explorer.html">GitHub Explorer</a></li>
+            <li><a href="rugby_game.html">AR Rugby</a></li>
         </ul>
     </nav>
     <main>

--- a/paywell.html
+++ b/paywell.html
@@ -33,6 +33,7 @@
             <li><a href="developer_tools.html">Developer Tools</a></li>
             <li><a href="ai_agent.html">AI Agent</a></li>
             <li><a href="github_explorer.html">GitHub Explorer</a></li>
+            <li><a href="rugby_game.html">AR Rugby</a></li>
         </ul>
     </nav>
     <main>

--- a/role_playing_games.html
+++ b/role_playing_games.html
@@ -32,6 +32,7 @@
             <li><a href="developer_tools.html">Developer Tools</a></li>
             <li><a href="ai_agent.html">AI Agent</a></li>
             <li><a href="github_explorer.html">GitHub Explorer</a></li>
+            <li><a href="rugby_game.html">AR Rugby</a></li>
         </ul>
     </nav>
     <main>

--- a/rugby_game.html
+++ b/rugby_game.html
@@ -1,0 +1,69 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>AR Rugby Game - Game Portal</title>
+    <link rel="stylesheet" href="style.css">
+    <meta name="description" content="A new AR HTML5 rugby game with Blockchain and AI.">
+</head>
+<body>
+    <header>
+        <h1>AR Rugby Game</h1>
+    </header>
+    <nav>
+        <ul>
+            <li><a href="ai_mmo_games.html">AI MMO Games</a></li>
+            <li><a href="manga_games.html">Manga Games</a></li>
+            <li><a href="casino_games.html">Casino Games</a></li>
+            <li><a href="global_gambles.html">Global Gambles</a></li>
+            <li><a href="forums.html">Forums</a></li>
+            <li class="nav-item"><a href="affiliates.html">Affiliates</a></li>
+            <li><a href="esport_games.html">E-sport Games</a></li>
+            <li><a href="instant_games.html">Instant Games</a></li>
+            <li><a href="partnerships.html">Partnerships</a></li>
+            <li><a href="camera_features.html">Camera Features</a></li>
+            <li><a href="paywell.html">Paywell Wallet</a></li>
+            <li><a href="cloud_gaming.html">Cloud Gaming</a></li>
+            <li><a href="sponsorship.html">Sponsor Us</a></li>
+            <li><a href="monetization.html">Monetization Info</a></li>
+            <li><a href="role_playing_games.html">Role-Playing Games</a></li>
+            <li><a href="developer_tools.html">Developer Tools</a></li>
+            <li><a href="ai_agent.html">AI Agent</a></li>
+            <li><a href="github_explorer.html">GitHub Explorer</a></li>
+            <li><a href="rugby_game.html">AR Rugby</a></li>
+        </ul>
+    </nav>
+    <main>
+        <section id="game-overview">
+            <h2>Game Overview</h2>
+            <p>Welcome to the future of sports gaming. Our AR Rugby game combines cutting-edge technology with the visceral excitement of the sport to deliver an unparalleled experience. Play in your world, build your team, and compete for glory.</p>
+        </section>
+
+        <section id="core-features">
+            <h3>Core Features</h3>
+            <ul>
+                <li><strong>Augmented Reality:</strong> Transform any flat surface into a rugby pitch.</li>
+                <li><strong>AI Opponents:</strong> Compete against intelligent AI teams that learn from your playstyle.</li>
+                <li><strong>Blockchain Integration:</strong> Own, trade, and manage your players as unique digital assets on the blockchain.</li>
+                <li><strong>Cross-Platform:</strong> Play on Meta Horizon, as a PWA on your desktop, or on your mobile device.</li>
+                <li><strong>Career Mode:</strong> Take your team from the local leagues to the world championship.</li>
+            </ul>
+        </section>
+
+        <section id="tech-stack">
+            <h3>Technology Stack</h3>
+            <p>This game will be built using a modern, web-first technology stack:</p>
+            <ul>
+                <li><strong>HTML5 & JavaScript:</strong> For a rich, interactive experience.</li>
+                <li><strong>WebXR API:</strong> To power the augmented reality features.</li>
+                <li><strong>Web3 Libraries:</strong> For seamless integration with blockchain networks.</li>
+                <li><strong>Advanced AI Models:</strong> For realistic opponent behavior and game simulation.</li>
+            </ul>
+        </section>
+    </main>
+    <footer>
+        <p>&copy; 2023 Game Portal</p>
+    </footer>
+</body>
+</html>

--- a/sponsorship.html
+++ b/sponsorship.html
@@ -32,6 +32,7 @@
             <li><a href="developer_tools.html">Developer Tools</a></li>
             <li><a href="ai_agent.html">AI Agent</a></li>
             <li><a href="github_explorer.html">GitHub Explorer</a></li>
+            <li><a href="rugby_game.html">AR Rugby</a></li>
         </ul>
     </nav>
     <main>


### PR DESCRIPTION
This commit introduces a new page for the AR Rugby game, as a first step in building the game requested by the user.

The new page, `rugby_game.html`, outlines the game's concept, features, and technology stack.

The navigation bar on all existing pages has been updated to include a link to the new game page.

## Summary by Sourcery

Introduce a new AR Rugby game page outlining the game concept, features, and tech stack, and update all existing pages’ navigation bars to link to it.

New Features:
- Add AR Rugby game page with overview, core features, and technology stack

Enhancements:
- Update site-wide navigation to include link to the AR Rugby game page