### PR TITLE
feat: Add license page and links

### DIFF
--- a/affiliates.html
+++ b/affiliates.html
@@ -31,6 +31,7 @@
             <li><a href="role_playing_games.html">Role-Playing Games</a></li>
             <li><a href="developer_tools.html">Developer Tools</a></li>
             <li><a href="github_explorer.html">GitHub Explorer</a></li>
+            <li><a href="license.html">License</a></li>
         </ul>
     </nav>
     <main>
@@ -58,7 +59,7 @@
 
     </main>
     <footer>
-        <p>&copy; 2023 Game Portal</p>
+        <p>&copy; 2023 Game Portal | <a href="license.html">License</a></p>
     </footer>
 </body>
 </html>

--- a/ai_mmo_games.html
+++ b/ai_mmo_games.html
@@ -30,6 +30,7 @@
             <li><a href="role_playing_games.html">Role-Playing Games</a></li>
             <li><a href="developer_tools.html">Developer Tools</a></li>
             <li><a href="github_explorer.html">GitHub Explorer</a></li>
+            <li><a href="license.html">License</a></li>
         </ul>
     </nav>
     <main>
@@ -37,7 +38,7 @@
         <!-- TODO: Add content about AI MMO games -->
     </main>
     <footer>
-        <p>&copy; 2023 Game Portal</p>
+        <p>&copy; 2023 Game Portal | <a href="license.html">License</a></p>
     </footer>
 </body>
 </html>

--- a/camera_features.html
+++ b/camera_features.html
@@ -31,6 +31,7 @@
             <li><a href="role_playing_games.html">Role-Playing Games</a></li>
             <li><a href="developer_tools.html">Developer Tools</a></li>
             <li><a href="github_explorer.html">GitHub Explorer</a></li>
+            <li><a href="license.html">License</a></li>
         </ul>
     </nav>
     <main>
@@ -94,7 +95,7 @@
 
     </main>
     <footer>
-        <p>&copy; 2023 Game Portal</p>
+        <p>&copy; 2023 Game Portal | <a href="license.html">License</a></p>
     </footer>
 </body>
 </html>

--- a/casino_games.html
+++ b/casino_games.html
@@ -30,6 +30,7 @@
             <li><a href="role_playing_games.html">Role-Playing Games</a></li>
             <li><a href="developer_tools.html">Developer Tools</a></li>
             <li><a href="github_explorer.html">GitHub Explorer</a></li>
+            <li><a href="license.html">License</a></li>
         </ul>
     </nav>
     <main>
@@ -37,7 +38,7 @@
         <!-- TODO: Add content about casino games -->
     </main>
     <footer>
-        <p>&copy; 2023 Game Portal</p>
+        <p>&copy; 2023 Game Portal | <a href="license.html">License</a></p>
     </footer>
 </body>
 </html>

--- a/cloud_gaming.html
+++ b/cloud_gaming.html
@@ -31,6 +31,7 @@
             <li><a href="role_playing_games.html">Role-Playing Games</a></li>
             <li><a href="developer_tools.html">Developer Tools</a></li>
             <li><a href="github_explorer.html">GitHub Explorer</a></li>
+            <li><a href="license.html">License</a></li>
         </ul>
     </nav>
     <main>
@@ -68,7 +69,7 @@
         </section>
     </main>
     <footer>
-        <p>&copy; 2023 Game Portal</p>
+        <p>&copy; 2023 Game Portal | <a href="license.html">License</a></p>
     </footer>
 </body>
 </html>

--- a/developer_tools.html
+++ b/developer_tools.html
@@ -50,6 +50,7 @@
             <li><a href="role_playing_games.html">Role-Playing Games</a></li>
             <li><a href="developer_tools.html">Developer Tools</a></li>
             <li><a href="github_explorer.html">GitHub Explorer</a></li>
+            <li><a href="license.html">License</a></li>
         </ul>
     </nav>
     <main>
@@ -168,7 +169,7 @@
         </script>
     </main>
     <footer>
-        <p>&copy; 2023 Game Portal</p>
+        <p>&copy; 2023 Game Portal | <a href="license.html">License</a></p>
     </footer>
 </body>
 </html>

--- a/esport_games.html
+++ b/esport_games.html
@@ -31,6 +31,7 @@
             <li><a href="role_playing_games.html">Role-Playing Games</a></li>
             <li><a href="developer_tools.html">Developer Tools</a></li>
             <li><a href="github_explorer.html">GitHub Explorer</a></li>
+            <li><a href="license.html">License</a></li>
         </ul>
     </nav>
     <main>
@@ -49,7 +50,7 @@
 
     </main>
     <footer>
-        <p>&copy; 2023 Game Portal</p>
+        <p>&copy; 2023 Game Portal | <a href="license.html">License</a></p>
     </footer>
 </body>
 </html>

--- a/forums.html
+++ b/forums.html
@@ -30,6 +30,7 @@
             <li><a href="role_playing_games.html">Role-Playing Games</a></li>
             <li><a href="developer_tools.html">Developer Tools</a></li>
             <li><a href="github_explorer.html">GitHub Explorer</a></li>
+            <li><a href="license.html">License</a></li>
         </ul>
     </nav>
     <main>
@@ -37,7 +38,7 @@
         <!-- TODO: Add content for forums -->
     </main>
     <footer>
-        <p>&copy; 2023 Game Portal</p>
+        <p>&copy; 2023 Game Portal | <a href="license.html">License</a></p>
     </footer>
 </body>
 </html>

--- a/github_explorer.html
+++ b/github_explorer.html
@@ -65,6 +65,7 @@
             <li><a href="role_playing_games.html">Role-Playing Games</a></li>
             <li><a href="developer_tools.html">Developer Tools</a></li>
             <li><a href="github_explorer.html">GitHub Explorer</a></li>
+            <li><a href="license.html">License</a></li>
         </ul>
     </nav>
     <main>
@@ -193,7 +194,7 @@
         </script>
     </main>
     <footer>
-        <p>&copy; 2023 Game Portal</p>
+        <p>&copy; 2023 Game Portal | <a href="license.html">License</a></p>
     </footer>
 </body>
 </html>

--- a/global_gambles.html
+++ b/global_gambles.html
@@ -30,6 +30,7 @@
             <li><a href="role_playing_games.html">Role-Playing Games</a></li>
             <li><a href="developer_tools.html">Developer Tools</a></li>
             <li><a href="github_explorer.html">GitHub Explorer</a></li>
+            <li><a href="license.html">License</a></li>
         </ul>
     </nav>
     <main>
@@ -37,7 +38,7 @@
         <!-- TODO: Add content about global gambles -->
     </main>
     <footer>
-        <p>&copy; 2023 Game Portal</p>
+        <p>&copy; 2023 Game Portal | <a href="license.html">License</a></p>
     </footer>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -31,13 +31,14 @@
             <li><a href="role_playing_games.html">Role-Playing Games</a></li>
             <li><a href="developer_tools.html">Developer Tools</a></li>
             <li><a href="github_explorer.html">GitHub Explorer</a></li>
+            <li><a href="license.html">License</a></li>
         </ul>
     </nav>
     <div style="text-align: center; padding: 20px;">
         <button id="nativeShareBtn" style="padding: 10px 20px; font-size: 1.1em; cursor: pointer;">Share this Portal!</button>
     </div>
     <footer>
-        <p>&copy; 2023 Game Portal</p>
+        <p>&copy; 2023 Game Portal | <a href="license.html">License</a></p>
     </footer>
     <script>
       // Service Worker Registration (existing code)

--- a/license.html
+++ b/license.html
@@ -3,13 +3,13 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Instant Games</title>
-    <meta name="description" content="Play a variety of fun and engaging instant games directly in your browser. No downloads needed, just click and play!">
+    <title>License - Game Portal</title>
     <link rel="stylesheet" href="style.css">
+    <meta name="description" content="License information for the Game Portal.">
 </head>
 <body>
     <header>
-        <h1>Instant Games</h1>
+        <h1>License</h1>
     </header>
     <nav>
         <ul>
@@ -19,7 +19,7 @@
             <li><a href="casino_games.html">Casino Games</a></li>
             <li><a href="global_gambles.html">Global Gambles</a></li>
             <li><a href="forums.html">Forums</a></li>
-            <li><a href="affiliates.html">Affiliates</a></li>
+            <li class="nav-item"><a href="affiliates.html">Affiliates</a></li>
             <li><a href="esport_games.html">E-sport Games</a></li>
             <li><a href="instant_games.html">Instant Games</a></li>
             <li><a href="partnerships.html">Partnerships</a></li>
@@ -31,24 +31,28 @@
             <li><a href="role_playing_games.html">Role-Playing Games</a></li>
             <li><a href="developer_tools.html">Developer Tools</a></li>
             <li><a href="github_explorer.html">GitHub Explorer</a></li>
-            <li><a href="license.html">License</a></li>
         </ul>
     </nav>
     <main>
-        <p>Play a variety of fun instant games directly in your browser!</p>
-
-        <section id="game-list">
-            <h2>Available Games</h2>
-            <p><em>(List or embed instant games here. You might need to use iframes or JavaScript for actual game embedding later.)</em></p>
-            <!-- Example:
-            <div class="game-item">
-                <h3>Game Title 1</h3>
-                <p>Short description of the game.</p>
-                <a href="#">Play Now!</a> or an embed code
-            </div>
-            -->
+        <section id="license-info">
+            <h2>MIT License</h2>
+            <p>Copyright (c) 2023 Game Portal</p>
+            <p>Permission is hereby granted, free of charge, to any person obtaining a copy
+            of this software and associated documentation files (the "Software"), to deal
+            in the Software without restriction, including without limitation the rights
+            to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+            copies of the Software, and to permit persons to whom the Software is
+            furnished to do so, subject to the following conditions:</p>
+            <p>The above copyright notice and this permission notice shall be included in all
+            copies or substantial portions of the Software.</p>
+            <p>THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+            IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+            FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+            AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+            LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+            OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+            SOFTWARE.</p>
         </section>
-
     </main>
     <footer>
         <p>&copy; 2023 Game Portal | <a href="license.html">License</a></p>

--- a/manga_games.html
+++ b/manga_games.html
@@ -30,6 +30,7 @@
             <li><a href="role_playing_games.html">Role-Playing Games</a></li>
             <li><a href="developer_tools.html">Developer Tools</a></li>
             <li><a href="github_explorer.html">GitHub Explorer</a></li>
+            <li><a href="license.html">License</a></li>
         </ul>
     </nav>
     <main>
@@ -37,7 +38,7 @@
         <!-- TODO: Add content about manga games -->
     </main>
     <footer>
-        <p>&copy; 2023 Game Portal</p>
+        <p>&copy; 2023 Game Portal | <a href="license.html">License</a></p>
     </footer>
 </body>
 </html>

--- a/monetization.html
+++ b/monetization.html
@@ -31,6 +31,7 @@
             <li><a href="role_playing_games.html">Role-Playing Games</a></li>
             <li><a href="developer_tools.html">Developer Tools</a></li>
             <li><a href="github_explorer.html">GitHub Explorer</a></li>
+            <li><a href="license.html">License</a></li>
         </ul>
     </nav>
     <main>
@@ -86,7 +87,7 @@
         </section>
     </main>
     <footer>
-        <p>&copy; 2023 Game Portal</p>
+        <p>&copy; 2023 Game Portal | <a href="license.html">License</a></p>
     </footer>
 </body>
 </html>

--- a/partnerships.html
+++ b/partnerships.html
@@ -31,6 +31,7 @@
             <li><a href="role_playing_games.html">Role-Playing Games</a></li>
             <li><a href="developer_tools.html">Developer Tools</a></li>
             <li><a href="github_explorer.html">GitHub Explorer</a></li>
+            <li><a href="license.html">License</a></li>
         </ul>
     </nav>
     <main>
@@ -66,7 +67,7 @@
 
     </main>
     <footer>
-        <p>&copy; 2023 Game Portal</p>
+        <p>&copy; 2023 Game Portal | <a href="license.html">License</a></p>
     </footer>
 </body>
 </html>

--- a/paywell.html
+++ b/paywell.html
@@ -32,6 +32,7 @@
             <li><a href="role_playing_games.html">Role-Playing Games</a></li>
             <li><a href="developer_tools.html">Developer Tools</a></li>
             <li><a href="github_explorer.html">GitHub Explorer</a></li>
+            <li><a href="license.html">License</a></li>
         </ul>
     </nav>
     <main>
@@ -68,7 +69,7 @@
         </section>
     </main>
     <footer>
-        <p>&copy; 2023 Game Portal</p>
+        <p>&copy; 2023 Game Portal | <a href="license.html">License</a></p>
     </footer>
 </body>
 </html>

--- a/role_playing_games.html
+++ b/role_playing_games.html
@@ -31,6 +31,7 @@
             <li><a href="role_playing_games.html">Role-Playing Games</a></li>
             <li><a href="developer_tools.html">Developer Tools</a></li>
             <li><a href="github_explorer.html">GitHub Explorer</a></li>
+            <li><a href="license.html">License</a></li>
         </ul>
     </nav>
     <main>
@@ -68,7 +69,7 @@
 
     </main>
     <footer>
-        <p>&copy; 2023 Game Portal</p>
+        <p>&copy; 2023 Game Portal | <a href="license.html">License</a></p>
     </footer>
 </body>
 </html>

--- a/sponsorship.html
+++ b/sponsorship.html
@@ -31,6 +31,7 @@
             <li><a href="role_playing_games.html">Role-Playing Games</a></li>
             <li><a href="developer_tools.html">Developer Tools</a></li>
             <li><a href="github_explorer.html">GitHub Explorer</a></li>
+            <li><a href="license.html">License</a></li>
         </ul>
     </nav>
     <main>
@@ -73,7 +74,7 @@
 
     </main>
     <footer>
-        <p>&copy; 2023 Game Portal</p>
+        <p>&copy; 2023 Game Portal | <a href="license.html">License</a></p>
     </footer>
 </body>
 </html>


### PR DESCRIPTION
This commit introduces a license page to the Game Portal website.

A new `license.html` page was created containing the MIT License. A "License" link was added to the navigation bar and footer on all pages for consistent site-wide navigation.