### PR TITLE
feat: Integrate mobile and PC games

### DIFF
--- a/games.html
+++ b/games.html
@@ -55,19 +55,42 @@
 
         async function fetchGames() {
             try {
-                const [localGamesResponse, nintendoGamesResponse, twitchGamesResponse, neuroscienceGamesResponse] = await Promise.all([
+                const [
+                    localGamesResponse,
+                    nintendoGamesResponse,
+                    twitchGamesResponse,
+                    neuroscienceGamesResponse,
+                    palmGamesResponse,
+                    tencentGamesResponse
+                ] = await Promise.all([
                     fetch('data/games.json'),
                     fetch('/api/nintendo/games', { headers: { 'X-API-Key': 'test-api-key' } }),
                     fetch('/api/twitch/games', { headers: { 'X-API-Key': 'test-api-key' } }),
-                    fetch('data/neuroscience_psychotherapy_games.json')
+                    fetch('data/neuroscience_psychotherapy_games.json'),
+                    fetch('/api/palm/games', { headers: { 'X-API-Key': 'test-api-key' } }),
+                    fetch('/api/tencent/games', { headers: { 'X-API-Key': 'test-api-key' } })
                 ]);
 
                 const localGames = await localGamesResponse.json();
                 const nintendoGames = await nintendoGamesResponse.json();
                 const twitchGames = await twitchGamesResponse.json();
                 const neuroscienceGames = await neuroscienceGamesResponse.json();
+                const palmGamesData = await palmGamesResponse.json();
+                const tencentGamesData = await tencentGamesResponse.json();
 
-                games = [...localGames, ...nintendoGames, ...twitchGames, ...neuroscienceGames];
+                const palmGames = palmGamesData.map(game => ({
+                    name: game.name,
+                    category: game.developer,
+                    link: game.download_link
+                }));
+
+                const tencentGames = tencentGamesData.map(game => ({
+                    name: game.name,
+                    category: game.developer,
+                    link: game.download_link
+                }));
+
+                games = [...localGames, ...nintendoGames, ...twitchGames, ...neuroscienceGames, ...palmGames, ...tencentGames];
                 displayGames(games);
             } catch (error) {
                 console.error('Error fetching games:', error);


### PR DESCRIPTION
Integrate mobile games from Palm Store and Tencent Games into the main game list.

- Fetches game data from `/api/palm/games` and `/api/tencent/games`.
- Transforms the data to match the existing format.
- Displays the mobile games alongside the other games.

## Summary by Sourcery

Integrate mobile games from Palm Store and Tencent Games by fetching, transforming, and displaying them with the existing game list.

New Features:
- Fetch mobile game data from the Palm Store and Tencent Games APIs
- Transform and normalize the fetched mobile game entries to match the existing game format
- Include and display Palm Store and Tencent mobile games alongside other games