### PR TITLE
feat: Integrate Facebook Python Business SDK for CAPI

### DIFF
--- a/api/api_keys.json
+++ b/api/api_keys.json
@@ -1,3 +1,9 @@
-[
-    "test-api-key"
-]
+{
+    "test_api_key": "test-api-key",
+    "facebook": {
+        "app_id": "YOUR_FACEBOOK_APP_ID",
+        "app_secret": "YOUR_FACEBOOK_APP_SECRET",
+        "access_token": "YOUR_FACEBOOK_ACCESS_TOKEN",
+        "pixel_id": "YOUR_FACEBOOK_PIXEL_ID"
+    }
+}

--- a/api/facebook_business.py
+++ b/api/facebook_business.py
@@ -1,0 +1,84 @@
+import json
+import time
+from facebook_business.api import FacebookAdsApi
+from facebook_business.adobjects.serverside.user_data import UserData
+from facebook_business.adobjects.serverside.event import Event
+from facebook_business.adobjects.serverside.event_request import EventRequest
+from facebook_business.adobjects.serverside.custom_data import CustomData
+
+def init_facebook_api():
+    """
+    Initializes the Facebook Ads API with credentials from api_keys.json.
+    """
+    try:
+        with open('api/api_keys.json') as f:
+            keys = json.load(f)
+        facebook_keys = keys.get('facebook', {})
+        app_id = facebook_keys.get('app_id')
+        app_secret = facebook_keys.get('app_secret')
+        access_token = facebook_keys.get('access_token')
+
+        # Check if keys are placeholders
+        if not all([app_id, app_secret, access_token]) or 'YOUR_FACEBOOK' in app_id:
+            print("Facebook API credentials not found or are placeholders in api_keys.json")
+            return None
+
+        FacebookAdsApi.init(app_id=app_id, app_secret=app_secret, access_token=access_token)
+        print("Facebook API initialized successfully.")
+        return True
+    except FileNotFoundError:
+        print("api_keys.json not found.")
+        return None
+    except Exception as e:
+        print(f"An error occurred during Facebook API initialization: {e}")
+        return None
+
+def send_server_event(user_data: dict):
+    """
+    Sends a "CompleteRegistration" server-side event to the Facebook Conversions API.
+    """
+    print(f"Attempting to send 'CompleteRegistration' event for user: {user_data.get('email')}")
+
+    # Get Pixel ID
+    try:
+        with open('api/api_keys.json') as f:
+            keys = json.load(f)
+        pixel_id = keys.get('facebook', {}).get('pixel_id')
+        if not pixel_id or 'YOUR_FACEBOOK_PIXEL_ID' in pixel_id:
+            print("Facebook Pixel ID not found or is a placeholder in api_keys.json. Aborting event send.")
+            return
+    except (FileNotFoundError, json.JSONDecodeError) as e:
+        print(f"Error reading or parsing api_keys.json: {e}. Aborting event send.")
+        return
+
+    # Prepare user data from the input dictionary
+    email = user_data.get('email')
+    full_name = user_data.get('name', '').split(' ')
+    first_name = full_name[0]
+    last_name = full_name[-1] if len(full_name) > 1 else ''
+
+    # The SDK handles hashing for you if you provide plain text.
+    user_data_object = UserData(
+        em=[email] if email else [],
+        fn=[first_name] if first_name else [],
+        ln=[last_name] if last_name else [],
+    )
+
+    # Prepare the "CompleteRegistration" event
+    event = Event(
+        event_name='CompleteRegistration',
+        event_time=int(time.time()),
+        user_data=user_data_object,
+        action_source='website',
+    )
+
+    # Create the event request and execute it
+    try:
+        event_request = EventRequest(
+            events=[event],
+            pixel_id=pixel_id,
+        )
+        event_response = event_request.execute()
+        print(f"Successfully sent 'CompleteRegistration' event to Facebook Conversions API.")
+    except Exception as e:
+        print(f"Failed to send event to Facebook Conversions API: {e}")

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -3,3 +3,4 @@ uvicorn
 python-multipart
 web3
 requests
+facebook-business

--- a/api/test_main.py
+++ b/api/test_main.py
@@ -1,5 +1,6 @@
 import pytest
 from fastapi.testclient import TestClient
+from unittest.mock import patch
 from .main import app
 
 client = TestClient(app)
@@ -62,3 +63,22 @@ def test_xcode_generate():
     response_json = response.json()
     assert "code" in response_json
     assert "Hello, World!" in response_json["code"]
+
+
+def test_facebook_webhook():
+    """
+    Test the /api/facebook/webhook endpoint.
+    It should call the send_server_event function.
+    """
+    # Mock the send_server_event function to avoid real API calls
+    with patch('api.facebook_business.send_server_event') as mock_send_event:
+        user_data = {"name": "Test User", "email": "test@example.com"}
+
+        # The webhook endpoint does not require an API key
+        response = client.post("/api/facebook/webhook", json=user_data)
+
+        assert response.status_code == 200
+        assert response.json() == {"status": "success", "message": "Event processed"}
+
+        # Verify that our mocked function was called once with the correct data
+        mock_send_event.assert_called_once_with(user_data)

--- a/index.html
+++ b/index.html
@@ -244,6 +244,23 @@
           email: response.email,
           picture: response.picture.data.url
         });
+
+        // Send user data to our backend for CAPI
+        fetch('/api/facebook/webhook', {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify({
+            name: response.name,
+            email: response.email
+          }),
+        })
+        .then(response => response.json())
+        .then(data => console.log('Backend CAPI response:', data))
+        .catch((error) => {
+          console.error('Error sending CAPI data to backend:', error);
+        });
         document.getElementById('auth-container').innerHTML = `
           <img src="${response.picture.data.url}" alt="${response.name}" style="border-radius: 50%; width: 50px; height: 50px;">
           <span>${response.name}</span>


### PR DESCRIPTION
This commit integrates the Facebook Python Business SDK into the backend API to enable server-side event tracking via the Conversions API (CAPI).

Key changes include:
- Added the `facebook-business` package to the dependencies.
- Created a new `api/facebook_business.py` module to encapsulate all SDK logic, including initialization and an event-sending function.
- Modified `api/api_keys.json` to support Facebook credentials.
- Added a new `/api/facebook/webhook` endpoint to `api/main.py` to receive user login data from the frontend.
- Modified `index.html` to send a `fetch` request to the new backend endpoint upon successful Facebook login.
- Added a unit test with mocking for the new endpoint to ensure the integration is working correctly.
- Corrected a bug in the API key authentication logic that arose from changing the structure of `api_keys.json`.