### PR TITLE
feat: Integrate Kickstarter and Patreon APIs with mock data

### DIFF
--- a/api/kickstarter.py
+++ b/api/kickstarter.py
@@ -1,0 +1,39 @@
+import json
+import os
+
+def get_projects(query: str):
+    """
+    Returns a list of mock Kickstarter projects.
+    This is a mock implementation because Kickstarter blocks scraping.
+    """
+    # Load mock data from a JSON file
+    dir_path = os.path.dirname(os.path.realpath(__file__))
+    data_path = os.path.join(dir_path, "..", "data", "kickstarter_projects.json")
+
+    try:
+        with open(data_path, "r") as f:
+            projects = json.load(f)
+    except (FileNotFoundError, json.JSONDecodeError):
+        # Return a default list if the file doesn't exist or is empty
+        projects = [
+            {
+                "title": "Awesome Game Project",
+                "blurb": "A revolutionary new game that will change everything.",
+                "link": "https://www.kickstarter.com/projects/user/awesome-game-project"
+            },
+            {
+                "title": "Indie RPG Adventure",
+                "blurb": "Explore a vast world in this epic role-playing game.",
+                "link": "https://www.kickstarter.com/projects/user/indie-rpg-adventure"
+            }
+        ]
+
+    # Filter projects based on the query
+    if not query:
+        return projects
+
+    query = query.lower()
+    return [
+        project for project in projects
+        if query in project["title"].lower() or query in project["blurb"].lower()
+    ]

--- a/api/main.py
+++ b/api/main.py
@@ -21,6 +21,8 @@ import mmo_games
 import who_api
 import fb_business
 import wescore
+import kickstarter
+import patreon
 
 app = FastAPI()
 
@@ -461,3 +463,28 @@ async def get_wescore_fixtures():
     Get all fixtures from the WeScore API.
     """
     return wescore.get_all_fixtures()
+
+# --- Kickstarter Endpoints ---
+
+@app.get("/api/kickstarter/projects", dependencies=[Depends(get_api_key)])
+async def get_kickstarter_projects(q: str = ""):
+    """
+    Get a list of all projects from Kickstarter.
+    """
+    return kickstarter.get_projects(q)
+
+# --- Patreon Endpoints ---
+
+@app.get("/api/patreon/campaigns", dependencies=[Depends(get_api_key)])
+async def get_patreon_campaigns():
+    """
+    Get a list of all campaigns from Patreon.
+    """
+    return patreon.get_campaigns()
+
+@app.get("/api/patreon/campaigns/{campaign_id}/patrons", dependencies=[Depends(get_api_key)])
+async def get_patreon_patrons(campaign_id: str):
+    """
+    Get a list of all patrons for a campaign from Patreon.
+    """
+    return patreon.get_patrons(campaign_id)

--- a/api/patreon.py
+++ b/api/patreon.py
@@ -1,0 +1,54 @@
+import json
+import os
+
+def get_campaigns():
+    """
+    Returns a list of mock Patreon campaigns.
+    This is a mock implementation because API keys were not available.
+    """
+    return _get_mock_data("patreon_campaigns.json", [
+        {
+            "id": "1",
+            "type": "campaign",
+            "attributes": {
+                "creation_name": "My Awesome Project",
+                "patron_count": 123,
+                "summary": "This is a summary of my awesome project."
+            }
+        }
+    ])
+
+def get_patrons(campaign_id: str):
+    """
+    Returns a list of mock patrons for a given campaign.
+    This is a mock implementation.
+    """
+    # In a real implementation, you would filter patrons by campaign_id
+    return _get_mock_data("patreon_patrons.json", [
+        {
+            "id": "101",
+            "type": "pledge",
+            "attributes": {
+                "amount_cents": 500
+            },
+            "relationships": {
+                "patron": {
+                    "data": {
+                        "id": "201",
+                        "type": "user"
+                    }
+                }
+            }
+        }
+    ])
+
+def _get_mock_data(filename: str, default_data: list):
+    """Helper to load mock data from a JSON file."""
+    dir_path = os.path.dirname(os.path.realpath(__file__))
+    data_path = os.path.join(dir_path, "..", "data", filename)
+
+    try:
+        with open(data_path, "r") as f:
+            return json.load(f)
+    except (FileNotFoundError, json.JSONDecodeError):
+        return default_data

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -4,3 +4,6 @@ python-multipart
 web3
 requests
 facebook-business
+patreon
+beautifulsoup4
+httpx

--- a/api/test_kickstarter.py
+++ b/api/test_kickstarter.py
@@ -1,0 +1,38 @@
+import unittest
+from unittest.mock import patch, mock_open
+from api import kickstarter
+import json
+
+class TestKickstarter(unittest.TestCase):
+
+    @patch('builtins.open', new_callable=mock_open, read_data=json.dumps([
+        {"title": "Test Project 1", "blurb": "A test blurb", "link": "http://test.com/1"},
+        {"title": "Another Project", "blurb": "Another blurb", "link": "http://test.com/2"}
+    ]))
+    def test_get_projects_success(self, mock_file):
+        # Call the function with a query that matches one project
+        projects = kickstarter.get_projects("test")
+        self.assertEqual(len(projects), 1)
+        self.assertEqual(projects[0]['title'], 'Test Project 1')
+
+        # Call the function without a query
+        projects = kickstarter.get_projects("")
+        self.assertEqual(len(projects), 2)
+
+    @patch('builtins.open', side_effect=FileNotFoundError)
+    def test_get_projects_file_not_found(self, mock_file):
+        # Call the function with a query that matches one project in the default list
+        projects = kickstarter.get_projects("awesome")
+        self.assertEqual(len(projects), 1)
+        self.assertEqual(projects[0]['title'], 'Awesome Game Project')
+
+        # Test with a query that doesn't match anything in the default list
+        projects = kickstarter.get_projects("non-existent")
+        self.assertEqual(len(projects), 0)
+
+        # Test without a query
+        projects = kickstarter.get_projects("")
+        self.assertEqual(len(projects), 2)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/api/test_patreon.py
+++ b/api/test_patreon.py
@@ -1,0 +1,31 @@
+import unittest
+from unittest.mock import patch, mock_open
+from api import patreon
+import json
+
+class TestPatreon(unittest.TestCase):
+
+    @patch('builtins.open', new_callable=mock_open, read_data=json.dumps([
+        {"id": "1", "attributes": {"creation_name": "Campaign 1"}}
+    ]))
+    def test_get_campaigns_success(self, mock_file):
+        campaigns = patreon.get_campaigns()
+        self.assertEqual(len(campaigns), 1)
+        self.assertEqual(campaigns[0]['attributes']['creation_name'], 'Campaign 1')
+
+    @patch('builtins.open', side_effect=FileNotFoundError)
+    def test_get_campaigns_file_not_found(self, mock_file):
+        campaigns = patreon.get_campaigns()
+        self.assertEqual(len(campaigns), 1)
+        self.assertEqual(campaigns[0]['attributes']['creation_name'], 'My Awesome Project')
+
+    @patch('builtins.open', new_callable=mock_open, read_data=json.dumps([
+        {"id": "101", "attributes": {"amount_cents": 500}}
+    ]))
+    def test_get_patrons_success(self, mock_file):
+        patrons = patreon.get_patrons("1")
+        self.assertEqual(len(patrons), 1)
+        self.assertEqual(patrons[0]['attributes']['amount_cents'], 500)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/data/kickstarter_projects.json
+++ b/data/kickstarter_projects.json
@@ -1,0 +1,17 @@
+[
+    {
+        "title": "Project Alpha",
+        "blurb": "A new game about exploring a mysterious island.",
+        "link": "https://www.kickstarter.com/projects/user/project-alpha"
+    },
+    {
+        "title": "Cyberpunk Racer",
+        "blurb": "Race through a futuristic city in this high-speed game.",
+        "link": "https://www.kickstarter.com/projects/user/cyberpunk-racer"
+    },
+    {
+        "title": "Fantasy Kingdom Builder",
+        "blurb": "Create and manage your own fantasy kingdom.",
+        "link": "https://www.kickstarter.com/projects/user/fantasy-kingdom-builder"
+    }
+]

--- a/data/patreon_campaigns.json
+++ b/data/patreon_campaigns.json
@@ -1,0 +1,20 @@
+[
+    {
+        "id": "1",
+        "type": "campaign",
+        "attributes": {
+            "creation_name": "Game Dev Studio",
+            "patron_count": 250,
+            "summary": "Support our journey in creating amazing indie games."
+        }
+    },
+    {
+        "id": "2",
+        "type": "campaign",
+        "attributes": {
+            "creation_name": "Pixel Art World",
+            "patron_count": 150,
+            "summary": "Join us in creating a vibrant world of pixel art."
+        }
+    }
+]

--- a/data/patreon_patrons.json
+++ b/data/patreon_patrons.json
@@ -1,0 +1,38 @@
+[
+    {
+        "id": "101",
+        "type": "pledge",
+        "attributes": {
+            "amount_cents": 500
+        },
+        "relationships": {
+            "patron": {
+                "data": {
+                    "id": "201",
+                    "type": "user",
+                    "attributes": {
+                        "full_name": "John Doe"
+                    }
+                }
+            }
+        }
+    },
+    {
+        "id": "102",
+        "type": "pledge",
+        "attributes": {
+            "amount_cents": 1000
+        },
+        "relationships": {
+            "patron": {
+                "data": {
+                    "id": "202",
+                    "type": "user",
+                    "attributes": {
+                        "full_name": "Jane Smith"
+                    }
+                }
+            }
+        }
+    }
+]

--- a/kickstarter.html
+++ b/kickstarter.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Kickstarter Projects</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <header>
+        <h1>Kickstarter Projects</h1>
+    </header>
+    <nav>
+        <a href="index.html">Home</a>
+    </nav>
+    <main>
+        <div id="projects-container"></div>
+    </main>
+    <script>
+        document.addEventListener('DOMContentLoaded', function() {
+            const projectsContainer = document.getElementById('projects-container');
+
+            // This is a placeholder for your actual API key
+            const API_KEY = 'test-api-key';
+
+            fetch('/api/kickstarter/projects', {
+                headers: {
+                    'X-API-Key': API_KEY
+                }
+            })
+            .then(response => {
+                if (!response.ok) {
+                    throw new Error('Network response was not ok');
+                }
+                return response.json();
+            })
+            .then(projects => {
+                projects.forEach(project => {
+                    const projectElement = document.createElement('div');
+                    projectElement.classList.add('project');
+                    projectElement.innerHTML = `
+                        <h2><a href="${project.link}" target="_blank">${project.title}</a></h2>
+                        <p>${project.blurb}</p>
+                    `;
+                    projectsContainer.appendChild(projectElement);
+                });
+            })
+            .catch(error => {
+                console.error('Error fetching Kickstarter projects:', error);
+                projectsContainer.innerHTML = '<p>Error loading projects. Please try again later.</p>';
+            });
+        });
+    </script>
+</body>
+</html>

--- a/patreon.html
+++ b/patreon.html
@@ -1,0 +1,56 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Patreon Campaigns</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <header>
+        <h1>Patreon Campaigns</h1>
+    </header>
+    <nav>
+        <a href="index.html">Home</a>
+    </nav>
+    <main>
+        <div id="campaigns-container"></div>
+    </main>
+    <script>
+        document.addEventListener('DOMContentLoaded', function() {
+            const campaignsContainer = document.getElementById('campaigns-container');
+
+            // This is a placeholder for your actual API key
+            const API_KEY = 'test-api-key';
+
+            fetch('/api/patreon/campaigns', {
+                headers: {
+                    'X-API-Key': API_KEY
+                }
+            })
+            .then(response => {
+                if (!response.ok) {
+                    throw new Error('Network response was not ok');
+                }
+                return response.json();
+            })
+            .then(campaigns => {
+                campaigns.forEach(campaign => {
+                    const campaignElement = document.createElement('div');
+                    campaignElement.classList.add('campaign');
+                    campaignElement.innerHTML = `
+                        <h2>${campaign.attributes.creation_name}</h2>
+                        <p>${campaign.attributes.summary}</p>
+                        <p><strong>Patrons:</strong> ${campaign.attributes.patron_count}</p>
+                    `;
+                    campaignsContainer.appendChild(campaignElement);
+                });
+            })
+            .catch(error => {
+                console.error('Error fetching Patreon campaigns:', error);
+                campaignsContainer.innerHTML = '<p>Error loading campaigns. Please try again later.</p>';
+            });
+        });
+    </script>
+</body>
+</html>


### PR DESCRIPTION
This commit integrates Kickstarter and Patreon APIs into the application.

Since the user could not provide API keys for Patreon and Kickstarter blocks scraping, both APIs are implemented with mock data loaded from JSON files.

- Adds mock API modules for Kickstarter and Patreon.
- Adds new endpoints to the FastAPI application to expose the mock data.
- Adds new HTML pages to display the data from the new APIs.
- Adds unit tests for the new mock API modules.
- Updates requirements.txt with necessary dependencies.

## Summary by Sourcery

Integrate Kickstarter and Patreon mock APIs into the application by adding mock modules, FastAPI endpoints, HTML views, unit tests, and necessary dependencies

New Features:
- Add mock API modules for Patreon and Kickstarter returning data from JSON fixtures
- Expose new FastAPI endpoints for fetching Kickstarter projects and Patreon campaigns and patrons
- Create HTML pages to display Kickstarter projects and Patreon campaigns via the new endpoints

Enhancements:
- Add unit tests for the mock Kickstarter and Patreon modules

Build:
- Update requirements.txt to include patreon, beautifulsoup4, and httpx

Tests:
- Introduce tests for fetching Kickstarter projects and Patreon campaigns and patrons

Chores:
- Add default mock data JSON files for Kickstarter projects, Patreon campaigns, and patrons