### PR TITLE
Integrate MotoGP games and API

### DIFF
--- a/api/motogp.py
+++ b/api/motogp.py
@@ -1,0 +1,11 @@
+import json
+
+def get_all_games():
+    """
+    Get a list of all MotoGP games.
+
+    For now, this returns mock data. In the future, this could be updated
+    to fetch data from the Sportradar API.
+    """
+    with open("/app/data/motogp_games.json", "r") as f:
+        return json.load(f)

--- a/api/test_motogp.py
+++ b/api/test_motogp.py
@@ -1,0 +1,30 @@
+import unittest
+from unittest.mock import patch, mock_open
+import json
+import motogp
+
+class TestMotoGP(unittest.TestCase):
+
+    def test_get_all_games(self):
+        # Mock the data that would be in the JSON file
+        mock_data = json.dumps([
+            {"name": "MotoGP 23", "description": "The official MotoGP game for the 2023 season.", "link": "https://motogp.com/en/game", "download_link": "https://store.steampowered.com/app/2165730/MotoGP23/"},
+            {"name": "MotoGP 22", "description": "Relive the 2022 season with all the official riders and tracks.", "link": "https://motogp.com/en/game", "download_link": "https://store.steampowered.com/app/1710580/MotoGP22/"}
+        ])
+
+        # Use mock_open to simulate opening the file
+        with patch('builtins.open', mock_open(read_data=mock_data)) as mock_file:
+            games = motogp.get_all_games()
+            self.assertEqual(len(games), 2)
+            self.assertEqual(games[0]['name'], 'MotoGP 23')
+            # Check that the file was opened with the correct path
+            mock_file.assert_called_once_with("/app/data/motogp_games.json", "r")
+
+    def test_get_all_games_file_not_found(self):
+        # Simulate a FileNotFoundError
+        with patch('builtins.open', side_effect=FileNotFoundError):
+            with self.assertRaises(FileNotFoundError):
+                motogp.get_all_games()
+
+if __name__ == '__main__':
+    unittest.main()

--- a/data/motogp_games.json
+++ b/data/motogp_games.json
@@ -1,0 +1,20 @@
+[
+    {
+        "name": "MotoGP 23",
+        "description": "The official MotoGP game for the 2023 season. Experience the thrill of the championship.",
+        "link": "https://motogp.com/en/game",
+        "download_link": "https://store.steampowered.com/app/2165730/MotoGP23/"
+    },
+    {
+        "name": "MotoGP 22",
+        "description": "Relive the 2022 season with all the official riders and tracks.",
+        "link": "https://motogp.com/en/game",
+        "download_link": "https://store.steampowered.com/app/1710580/MotoGP22/"
+    },
+    {
+        "name": "MotoGP 21",
+        "description": "The most realistic and immersive MotoGP videogame experience is back.",
+        "link": "https://motogp.com/en/game",
+        "download_link": "https://store.steampowered.com/app/1477960/MotoGP21/"
+    }
+]

--- a/motogp_games.html
+++ b/motogp_games.html
@@ -1,0 +1,77 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>MotoGP Games - Official Motorcycle Racing - Games Universe</title>
+    <meta name="description" content="Explore the world of MotoGP with our collection of official motorcycle racing games. Get ready for high-octane action.">
+    <meta name="keywords" content="motogp, motorcycle racing, racing games, motogp 23, motogp 22">
+    <link rel="stylesheet" href="style.css">
+    <link rel="stylesheet" href="modal.css">
+</head>
+<body>
+    <header>
+        <h1>MotoGP Games</h1>
+    </header>
+    <div id="nav-placeholder"></div>
+    <main>
+        <section class="all-games">
+            <div class="container">
+                <h2>MotoGP Games</h2>
+                <div id="gameResults" class="category-grid">
+                    <!-- Game results will be displayed here -->
+                </div>
+            </div>
+        </section>
+    </main>
+    <footer>
+        <p>&copy; 2023 Game Portal</p>
+    </footer>
+    <script src="modal.js" defer></script>
+    <script>
+      fetch('nav_secondary.html')
+        .then(response => response.text())
+        .then(data => {
+          document.getElementById('nav-placeholder').innerHTML = data;
+        });
+
+        async function fetchGames() {
+            try {
+                const response = await fetch('/api/motogp/games', {
+                    headers: {
+                        'X-API-Key': 'test-api-key'
+                    }
+                });
+                const games = await response.json();
+                displayGames(games);
+            } catch (error) {
+                console.error('Error fetching games:', error);
+            }
+        }
+
+        function displayGames(gamesToDisplay) {
+            const gameResults = document.getElementById('gameResults');
+            gameResults.innerHTML = '';
+
+            if (gamesToDisplay.length === 0) {
+                gameResults.innerHTML = '<p>No games found.</p>';
+                return;
+            }
+
+            gamesToDisplay.forEach(game => {
+                const gameCard = document.createElement('div');
+                gameCard.className = 'category-card';
+                gameCard.innerHTML = `
+                    <h3>${game.name}</h3>
+                    <p>${game.description}</p>
+                    <a href="${game.link}" target="_blank">Play Now</a>
+                    <a href="${game.download_link}" target="_blank" class="download-button">Download</a>
+                `;
+                gameResults.appendChild(gameCard);
+            });
+        }
+
+        window.onload = fetchGames;
+    </script>
+</body>
+</html>

--- a/nav_secondary.html
+++ b/nav_secondary.html
@@ -8,6 +8,7 @@
         <li class="nav-item"><a href="affiliates.html">Affiliates</a></li>
         <li><a href="esport_games.html">E-sport Games</a></li>
         <li><a href="shooting_games.html">Shooting Games</a></li>
+        <li><a href="motogp_games.html">MotoGP Games</a></li>
         <li><a href="olympic_games.html">Olympic Games</a></li>
         <li><a href="instant_games.html">Instant Games</a></li>
         <li><a href="partnerships.html">Partnerships</a></li>


### PR DESCRIPTION
## Summary by Sourcery

Integrate MotoGP games into the site by adding a front-end page under navigation, implementing an API to serve game data from a JSON file, and adding corresponding tests.

New Features:
- Introduce MotoGP Games section in navigation and new motogp_games.html page that dynamically fetches and displays games
- Implement backend motogp.get_all_games function to load MotoGP games data from JSON
- Fetch and render MotoGP games on page load using the /api/motogp/games endpoint

Tests:
- Add unit tests for get_all_games covering successful data load and handling FileNotFoundError

Chores:
- Add placeholder motogp_games.json data file