### PR TITLE
feat: Integrate Netflix Games

### DIFF
--- a/api/conftest.py
+++ b/api/conftest.py
@@ -1,0 +1,25 @@
+import pytest
+import json
+import os
+
+@pytest.fixture(autouse=True)
+def api_keys_fixture():
+    """
+    Creates a dummy api_keys.json file for testing.
+    This fixture is automatically used by all tests.
+    """
+    api_keys = {
+        "test-key": "test-api-key",
+        "tiktok": {
+            "client_key": "test_client_key",
+            "client_secret": "test_client_secret"
+        }
+    }
+    with open("api_keys.json", "w") as f:
+        json.dump(api_keys, f)
+
+    yield
+
+    # Clean up the dummy api_keys.json file
+    if os.path.exists("api_keys.json"):
+        os.remove("api_keys.json")

--- a/api/main.py
+++ b/api/main.py
@@ -20,6 +20,7 @@ import ubisoft
 import rival
 import mmo_games
 import minecraft
+import netflix_games
 import redbull
 import who_api
 import fb_business
@@ -328,6 +329,15 @@ async def get_redbull_games():
     Get a list of all games from Red Bull.
     """
     return redbull.get_all_games()
+
+# --- Netflix Games Endpoints ---
+
+@app.get("/api/netflix/games", dependencies=[Depends(get_api_key)])
+async def get_netflix_games():
+    """
+    Get a list of all games from Netflix.
+    """
+    return netflix_games.get_netflix_games()
 
 # --- Rival Endpoints ---
 

--- a/api/netflix_games.py
+++ b/api/netflix_games.py
@@ -1,0 +1,53 @@
+import requests
+from bs4 import BeautifulSoup
+import json
+import os
+
+def get_netflix_games():
+    """
+    Scrapes the IPVanish website to get a list of Netflix games and their descriptions.
+    """
+    URL = "https://www.ipvanish.com/blog/best-games-on-netflix/"
+    try:
+        response = requests.get(URL)
+        response.raise_for_status()  # Raise an exception for bad status codes
+    except requests.exceptions.RequestException as e:
+        print(f"Error fetching the URL: {e}")
+        return []
+
+    soup = BeautifulSoup(response.content, 'html.parser')
+    games = []
+
+    # The game titles are in h3 tags, and the descriptions are in the following p tags.
+    for h3 in soup.find_all('h3'):
+        title = h3.get_text(strip=True)
+        # Stop if we reach the "How Netflix Games works" section
+        if "How Netflix Games works" in title:
+            break
+
+        # Find the next p tag which should be the description
+        description_tag = h3.find_next_sibling('p')
+        if description_tag:
+            description = description_tag.get_text(strip=True)
+            games.append({'title': title, 'description': description})
+
+    return games
+
+def save_games_to_json():
+    """
+    Saves the scraped games to a JSON file.
+    """
+    games = get_netflix_games()
+    if games:
+        # Build the path relative to the current file
+        dir_path = os.path.dirname(os.path.realpath(__file__))
+        file_path = os.path.join(dir_path, '..', 'frontend', 'data', 'netflix_games.json')
+
+        with open(file_path, 'w') as f:
+            json.dump(games, f, indent=4)
+        print(f"Successfully saved {len(games)} games to {file_path}")
+    else:
+        print("No games found or error in scraping.")
+
+if __name__ == '__main__':
+    save_games_to_json()

--- a/api/test_netflix_games.py
+++ b/api/test_netflix_games.py
@@ -1,0 +1,30 @@
+import unittest
+from fastapi.testclient import TestClient
+from api.main import app
+
+class TestNetflixGames(unittest.TestCase):
+    def setUp(self):
+        self.client = TestClient(app)
+        # You might need to set up a test API key if your endpoint is protected
+        self.api_key = "test-api-key"  # Replace with a valid test key if needed
+        self.headers = {"X-API-Key": self.api_key}
+
+    def test_get_netflix_games(self):
+        """
+        Test that the /api/netflix/games endpoint returns a list of games.
+        """
+        # Make a request to the endpoint
+        response = self.client.get("/api/netflix/games", headers=self.headers)
+
+        # Assert that the response is successful
+        self.assertEqual(response.status_code, 200)
+
+        # Assert that the response contains a list of games
+        games = response.json()
+        self.assertIsInstance(games, list)
+        if games:
+            self.assertIn("title", games[0])
+            self.assertIn("description", games[0])
+
+if __name__ == '__main__':
+    unittest.main()

--- a/api/test_tiktok.py
+++ b/api/test_tiktok.py
@@ -11,21 +11,6 @@ from api import tiktok
 
 class TestTikTok(unittest.TestCase):
 
-    def setUp(self):
-        # Create a dummy api_keys.json file for testing
-        self.api_keys = {
-            "tiktok": {
-                "client_key": "test_client_key",
-                "client_secret": "test_client_secret"
-            }
-        }
-        with open("api/api_keys.json", "w") as f:
-            json.dump(self.api_keys, f)
-
-    def tearDown(self):
-        # Clean up the dummy api_keys.json file
-        if os.path.exists("api/api_keys.json"):
-            os.remove("api/api_keys.json")
 
     @patch("api.tiktok.requests.post")
     def test_get_access_token(self, mock_post):

--- a/api/test_unesco.py
+++ b/api/test_unesco.py
@@ -3,6 +3,8 @@ from fastapi.testclient import TestClient
 from main import app, get_api_key
 from unittest.mock import patch
 
+import json
+import os
 class TestUnesco(unittest.TestCase):
     def setUp(self):
         self.client = TestClient(app)

--- a/frontend/data/netflix_games.json
+++ b/frontend/data/netflix_games.json
@@ -1,0 +1,54 @@
+[
+    {
+        "title": "Hades",
+        "description": "Hadesis a critically acclaimed roguelike dungeon crawler developed by Supergiant Games. You play as Zagreus, the son of Hades, in an attempt to escape the underworld. The game combines fast-paced combat with a deep narrative featuring Greek gods and heroes. With ever-changing dungeons, permanent upgrades, and rich character interactions, Hades offers endless replayability and narrative depth."
+    },
+    {
+        "title": "Dead Cells",
+        "description": "Dead Cellsis a rogue-lite, Metroidvania-inspired action-platformer. Players explore a sprawling, ever-changing castle, battling enemies, collecting weapons, and unlocking abilities. The game combines challenging combat with fluid movement and progression while offering a strong pixel art aesthetic."
+    },
+    {
+        "title": "Into the Breach",
+        "description": "From the creators ofFTL: Faster Than Light,Into the Breachis a tactical, turn-based strategy game where players control squads of powerful mechs to fight off alien invaders. Each battle plays out on a grid, and players must carefully plan their moves to save cities and complete objectives."
+    },
+    {
+        "title": "Arcanium",
+        "description": "Arcaniumis a strategic card battler with rogue-like mechanics. Set in a fantasy world, players build a team of heroes to battle enemies using a deck-building system. With a mix of strategic depth and engaging roguelike progression, it offers a complex and rewarding experience for fans of card-based gameplay."
+    },
+    {
+        "title": "Rainbow 6 SMOL",
+        "description": "Rainbow 6 SMOLis a mobile-friendly take on the classicRainbow Sixformula. This strategy-based shooter focuses on enhancing operators\u2019 abilities and building stats, providing fast-paced, tactical gameplay in a streamlined format. With no ads or in-app purchases, it\u2019s designed for mobile gaming with minimal distractions."
+    },
+    {
+        "title": "Into the Dead 2",
+        "description": "Into the Dead 2is a zombie-themed action-shooter game that blends survival and storytelling. Players navigate through waves of zombies, using weapons and strategy to survive. With a strong narrative, immersive gameplay, and visually striking graphics, it stands out as one of the more exciting mobile."
+    },
+    {
+        "title": "TMNT: Shredder\u2019s Revenge",
+        "description": "Teenage Mutant Ninja Turtles: Shredder\u2019s Revengeis a beat-em-up action game that pays homage to the classic arcade-style TMNT games from the 90s. Players can choose from a variety of characters, including all four turtles, as they fight through colorful levels filled with enemies and bosses in cooperative or solo play."
+    },
+    {
+        "title": "Death\u2019s Door",
+        "description": "Death\u2019s Dooris an action-adventure game where players control a small crow who works as a reaper, collecting souls. The game is known for its atmospheric world, clever puzzles, and challenging combat. Players explore different areas, each with their own set of enemies and secrets to uncover."
+    },
+    {
+        "title": "Spiritfarer",
+        "description": "Spiritfareris a management and adventure game about ferrying spirits to the afterlife. Players take on the role of Stella, a spiritfarer who helps spirits come to terms with their lives before they pass on. With a focus on empathy and care, the game offers heartfelt stories, emotional moments, and beautiful artwork."
+    },
+    {
+        "title": "Katana Zero",
+        "description": "Katana Zerois a fast-paced action platformer where players control a katana-wielding assassin with the ability to manipulate time. The gameplay emphasizes strategy, quick reflexes, and careful planning as players face off against enemies in each level. The game is known for its neo-noir aesthetic and twisty narrative."
+    },
+    {
+        "title": "Braid",
+        "description": "Braidis a unique puzzle platformer where players manipulate time to solve intricate puzzles. The game tells the story of a man named Tim on a journey to rescue a princess, but it unfolds with deeper philosophical themes and unexpected twists.Braidis renowned for its challenging puzzles and thought-provoking narrative."
+    },
+    {
+        "title": "Are Netflix games free?",
+        "description": "Sort of. You won\u2019t need to pay any additional fees, as Netflix Games are included in your standard subscription. But you need a Netflix subscription, so technically, you\u2019re paying for access as part of your monthly Netflix bill\u2014but there\u2019s no separate cost beyond that."
+    },
+    {
+        "title": "How do you play Netflix games?",
+        "description": "Netflix Games are exclusively available onmobile devices. They\u2019re compatible with iPhones, iPads, and Android. Take your next gaming adventure wherever you go!"
+    }
+]

--- a/frontend/nav_secondary.html
+++ b/frontend/nav_secondary.html
@@ -2,6 +2,7 @@
     <ul>
         <li><a href="index.html">Home</a></li>
         <li><a href="ai_mmo_games.html">AI MMO Games</a></li>
+        <li><a href="netflix_games.html">Netflix Games</a></li>
         <li><a href="manga_games.html">Manga Games</a></li>
         <li><a href="casino_games.html">Casino Games</a></li>
         <li><a href="forums.html">Forums</a></li>

--- a/frontend/netflix_games.html
+++ b/frontend/netflix_games.html
@@ -1,0 +1,71 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Netflix Games - Play on your mobile - Games Universe</title>
+    <meta name="description" content="Explore a curated library of games available with your Netflix subscription.">
+    <meta name="keywords" content="netflix games, mobile games, gaming, Hades, Dead Cells, Spiritfarer">
+    <link rel="stylesheet" href="style.css">
+    <link rel="stylesheet" href="modal.css">
+</head>
+<body>
+    <header>
+        <h1>Netflix Games</h1>
+    </header>
+    <div id="nav-placeholder"></div>
+    <main>
+        <section class="all-games">
+            <div class="container">
+                <h2>Netflix Games</h2>
+                <div id="gameResults" class="category-grid">
+                    <!-- Game results will be displayed here -->
+                </div>
+            </div>
+        </section>
+    </main>
+    <footer>
+        <p>&copy; 2023 Game Portal</p>
+    </footer>
+    <script src="modal.js" defer></script>
+    <script>
+      fetch('nav_secondary.html')
+        .then(response => response.text())
+        .then(data => {
+          document.getElementById('nav-placeholder').innerHTML = data;
+        });
+
+        async function fetchGames() {
+            try {
+                const response = await fetch('data/netflix_games.json');
+                const games = await response.json();
+                displayGames(games);
+            } catch (error) {
+                console.error('Error fetching games:', error);
+            }
+        }
+
+        function displayGames(gamesToDisplay) {
+            const gameResults = document.getElementById('gameResults');
+            gameResults.innerHTML = '';
+
+            if (gamesToDisplay.length === 0) {
+                gameResults.innerHTML = '<p>No games found.</p>';
+                return;
+            }
+
+            gamesToDisplay.forEach(game => {
+                const gameCard = document.createElement('div');
+                gameCard.className = 'category-card';
+                gameCard.innerHTML = `
+                    <h3>${game.title}</h3>
+                    <p>${game.description}</p>
+                `;
+                gameResults.appendChild(gameCard);
+            });
+        }
+
+        window.onload = fetchGames;
+    </script>
+</body>
+</html>


### PR DESCRIPTION
This commit adds a new feature to integrate Netflix games into the application.

- Adds a new Python script `api/netflix_games.py` to scrape Netflix games from a website.
- Adds a new endpoint `/api/netflix/games` to `api/main.py` to serve the scraped data.
- Creates a new HTML file `frontend/netflix_games.html` to display the games.
- Adds a new data file `frontend/data/netflix_games.json` to store the scraped data.
- Adds a link to the new page in the main navigation.
- Adds tests for the new API endpoint.
- Refactors the test suite to use a `conftest.py` file for managing API keys.